### PR TITLE
fix: expire preview clones after 7 days

### DIFF
--- a/cleanup.go
+++ b/cleanup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"mintlify-previewer-backend/log"
@@ -14,6 +15,40 @@ import (
 const previewTTL = 7 * 24 * time.Hour
 
 var removeAll = os.RemoveAll
+
+var inflightMu sync.Mutex
+var inflight = map[string]int{}
+
+func beginInflight(uuid string) {
+	inflightMu.Lock()
+	inflight[uuid]++
+	inflightMu.Unlock()
+}
+
+func endInflight(uuid string) {
+	inflightMu.Lock()
+	inflight[uuid]--
+	if inflight[uuid] <= 0 {
+		delete(inflight, uuid)
+	}
+	inflightMu.Unlock()
+}
+
+func waitInflight(uuid string, d time.Duration) bool {
+	deadline := time.Now().Add(d)
+	for {
+		inflightMu.Lock()
+		n := inflight[uuid]
+		inflightMu.Unlock()
+		if n == 0 {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
 
 const cleanupInterval = time.Hour
 
@@ -105,6 +140,11 @@ func teardownDeployment(database *sql.DB, root, uuid string) {
 	// Stop the row first so an in-flight start cannot write status=running
 	// after DELETE returns. deleted_at waits until the clone dir is gone.
 	markDeploymentStopped(database, uuid)
+	if !waitInflight(uuid, 30*time.Second) {
+		log.Errorf("Timed out waiting for in-flight work on %s; leaving clone for retry", uuid)
+		stopMintlifyProcess(uuid)
+		return
+	}
 	stopMintlifyProcess(uuid)
 	dir := filepath.Join(root, uuid)
 	if err := removeAll(dir); err != nil {

--- a/cleanup.go
+++ b/cleanup.go
@@ -11,9 +11,9 @@ import (
 )
 
 // previewTTL is how long a clone and mintlify process stay on disk.
-// Each preview copies the full website tree; without a cutoff those
-// directories fill the VM (71 clones were 19 GB when the 30 GB disk died).
 const previewTTL = 7 * 24 * time.Hour
+
+var removeAll = os.RemoveAll
 
 const cleanupInterval = time.Hour
 
@@ -102,22 +102,15 @@ func expireDeployments(database *sql.DB, root string, ttl time.Duration) {
 }
 
 func teardownDeployment(database *sql.DB, root, uuid string) {
+	// Stop the row first so an in-flight start cannot write status=running
+	// after DELETE returns. deleted_at waits until the clone dir is gone.
+	markDeploymentStopped(database, uuid)
 	stopMintlifyProcess(uuid)
 	dir := filepath.Join(root, uuid)
-	if err := os.RemoveAll(dir); err != nil {
+	if err := removeAll(dir); err != nil {
 		log.Errorf("Failed to remove preview dir %s: %v", dir, err)
-	}
-	if database == nil {
 		return
 	}
-	_, err := database.Exec(`
-		UPDATE deployments
-		SET status = ?, deleted_at = CURRENT_TIMESTAMP
-		WHERE uuid = ? AND deleted_at IS NULL
-	`, "stopped", uuid)
-	if err != nil {
-		log.Errorf("Failed to mark deployment %s stopped: %v", uuid, err)
-		return
-	}
+	markDeploymentDeleted(database, uuid)
 	log.Infof("Expired preview %s", uuid)
 }

--- a/cleanup.go
+++ b/cleanup.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"mintlify-previewer-backend/log"
+)
+
+// previewTTL is how long a clone and mintlify process stay on disk.
+// Each preview copies the full website tree; without a cutoff those
+// directories fill the VM (71 clones were 19 GB when the 30 GB disk died).
+const previewTTL = 7 * 24 * time.Hour
+
+const cleanupInterval = time.Hour
+
+func reposRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ".repos"
+	}
+	return filepath.Join(dir, ".repos")
+}
+
+func startCleanupLoop() {
+	expireOldDeployments()
+	go func() {
+		t := time.NewTicker(cleanupInterval)
+		defer t.Stop()
+		for range t.C {
+			expireOldDeployments()
+		}
+	}()
+}
+
+func expireOldDeployments() {
+	expireDeployments(db, reposRoot(), previewTTL)
+}
+
+func expireDeployments(database *sql.DB, root string, ttl time.Duration) {
+	if database == nil {
+		return
+	}
+
+	mod := fmt.Sprintf("-%d hours", int(ttl.Hours()))
+	rows, err := database.Query(`
+		SELECT uuid FROM deployments
+		WHERE deleted_at IS NULL
+		  AND (status IN ('failed', 'stopped') OR created_at <= datetime('now', ?))
+	`, mod)
+	if err != nil {
+		log.Errorf("Failed to query expired deployments: %v", err)
+		return
+	}
+
+	var uuids []string
+	for rows.Next() {
+		var uuid string
+		if err := rows.Scan(&uuid); err != nil {
+			log.Errorf("Failed to scan expired deployment: %v", err)
+			continue
+		}
+		uuids = append(uuids, uuid)
+	}
+	_ = rows.Close()
+
+	seen := make(map[string]struct{}, len(uuids))
+	for _, uuid := range uuids {
+		seen[uuid] = struct{}{}
+		teardownDeployment(database, root, uuid)
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Errorf("Failed to list %s: %v", root, err)
+		}
+		return
+	}
+
+	cutoff := time.Now().Add(-ttl)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		uuid := entry.Name()
+		if _, ok := seen[uuid]; ok {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(cutoff) {
+			continue
+		}
+		teardownDeployment(database, root, uuid)
+	}
+}
+
+func teardownDeployment(database *sql.DB, root, uuid string) {
+	stopMintlifyProcess(uuid)
+	dir := filepath.Join(root, uuid)
+	if err := os.RemoveAll(dir); err != nil {
+		log.Errorf("Failed to remove preview dir %s: %v", dir, err)
+	}
+	if database == nil {
+		return
+	}
+	_, err := database.Exec(`
+		UPDATE deployments
+		SET status = ?, deleted_at = CURRENT_TIMESTAMP
+		WHERE uuid = ? AND deleted_at IS NULL
+	`, "stopped", uuid)
+	if err != nil {
+		log.Errorf("Failed to mark deployment %s stopped: %v", uuid, err)
+		return
+	}
+	log.Infof("Expired preview %s", uuid)
+}

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -244,6 +244,22 @@ func TestWaitInflightBlocksUntilEnd(t *testing.T) {
 	}
 }
 
+func TestCloneIfActiveAbortsStopped(t *testing.T) {
+	database := testDB(t)
+	root := filepath.Join(t.TempDir(), ".repos")
+	dir := mkdirPreview(t, root, "gone")
+	insertDeployment(t, database, "gone", "starting", "datetime('now')")
+	markDeploymentStopped(database, "gone")
+
+	aborted, err := cloneIfActive(database, "gone", "https://example.com/x.git", "main", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !aborted {
+		t.Fatal("stopped row should abort before clone")
+	}
+}
+
 func TestWaitInflightTimesOut(t *testing.T) {
 	const uuid = "inflight-timeout"
 	beginInflight(uuid)

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func testDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "deployments.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	_, err = db.Exec(`
+		CREATE TABLE deployments (
+			uuid TEXT PRIMARY KEY,
+			github_url TEXT,
+			branch TEXT,
+			docs_path TEXT,
+			deployment_url TEXT,
+			deployment_proxy_url TEXT,
+			status TEXT,
+			error TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			deleted_at DATETIME
+		)
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func insertDeployment(t *testing.T, db *sql.DB, uuid, status, createdSQL string) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO deployments (uuid, status, created_at) VALUES (?, ?, `+createdSQL+`)`,
+		uuid, status,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mkdirPreview(t *testing.T, root, uuid string) string {
+	t.Helper()
+	dir := filepath.Join(root, uuid)
+	if err := os.MkdirAll(filepath.Join(dir, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestExpireDeploymentsRemovesOldAndFailed(t *testing.T) {
+	database := testDB(t)
+	root := filepath.Join(t.TempDir(), ".repos")
+
+	oldDir := mkdirPreview(t, root, "old-running")
+	freshDir := mkdirPreview(t, root, "fresh-running")
+	failedDir := mkdirPreview(t, root, "failed-now")
+	orphanDir := mkdirPreview(t, root, "orphan-old")
+
+	insertDeployment(t, database, "old-running", "running", "datetime('now', '-8 days')")
+	insertDeployment(t, database, "fresh-running", "running", "datetime('now')")
+	insertDeployment(t, database, "failed-now", "failed", "datetime('now')")
+
+	oldMtime := time.Now().Add(-8 * 24 * time.Hour)
+	if err := os.Chtimes(orphanDir, oldMtime, oldMtime); err != nil {
+		t.Fatal(err)
+	}
+
+	expireDeployments(database, root, 7*24*time.Hour)
+
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatalf("old running clone should be removed, err=%v", err)
+	}
+	if _, err := os.Stat(failedDir); !os.IsNotExist(err) {
+		t.Fatalf("failed clone should be removed, err=%v", err)
+	}
+	if _, err := os.Stat(orphanDir); !os.IsNotExist(err) {
+		t.Fatalf("stale orphan clone should be removed, err=%v", err)
+	}
+	if _, err := os.Stat(freshDir); err != nil {
+		t.Fatalf("fresh running clone should remain: %v", err)
+	}
+
+	var oldDeleted, failedDeleted sql.NullString
+	if err := database.QueryRow(`SELECT deleted_at FROM deployments WHERE uuid = ?`, "old-running").Scan(&oldDeleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.QueryRow(`SELECT deleted_at FROM deployments WHERE uuid = ?`, "failed-now").Scan(&failedDeleted); err != nil {
+		t.Fatal(err)
+	}
+	if !oldDeleted.Valid {
+		t.Fatal("old running row should set deleted_at")
+	}
+	if !failedDeleted.Valid {
+		t.Fatal("failed row should set deleted_at")
+	}
+
+	var freshStatus string
+	var freshDeleted sql.NullString
+	if err := database.QueryRow(`SELECT status, deleted_at FROM deployments WHERE uuid = ?`, "fresh-running").Scan(&freshStatus, &freshDeleted); err != nil {
+		t.Fatal(err)
+	}
+	if freshStatus != "running" || freshDeleted.Valid {
+		t.Fatalf("fresh row mutated: status=%s deleted=%v", freshStatus, freshDeleted.Valid)
+	}
+}

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -121,20 +121,25 @@ func TestSetStatusIfActiveIgnoresStopped(t *testing.T) {
 	insertDeployment(t, database, "gone", "starting", "datetime('now')")
 	markDeploymentStopped(database, "gone")
 
-	if !isDeploymentActive(database, "live") {
-		t.Fatal("starting row should be active")
+	active, err := deploymentActive(database, "live")
+	if err != nil || !active {
+		t.Fatalf("starting row should be active, active=%v err=%v", active, err)
 	}
-	if isDeploymentActive(database, "gone") {
-		t.Fatal("stopped row should not be active")
+	active, err = deploymentActive(database, "gone")
+	if err != nil || active {
+		t.Fatalf("stopped row should not be active, active=%v err=%v", active, err)
 	}
-	if !setStatusIfActive(database, "live", "running") {
-		t.Fatal("starting row should accept running")
+	ok, err := setStatusIfActive(database, "live", "running")
+	if err != nil || !ok {
+		t.Fatalf("starting row should accept running, ok=%v err=%v", ok, err)
 	}
-	if setStatusIfActive(database, "gone", "running") {
-		t.Fatal("stopped row must not accept running")
+	ok, err = setStatusIfActive(database, "gone", "running")
+	if err != nil || ok {
+		t.Fatalf("stopped row must not accept running, ok=%v err=%v", ok, err)
 	}
-	if setFailedIfActive(database, "gone", "clone failed") {
-		t.Fatal("stopped row must not accept failed")
+	ok, err = setFailedIfActive(database, "gone", "clone failed")
+	if err != nil || ok {
+		t.Fatalf("stopped row must not accept failed, ok=%v err=%v", ok, err)
 	}
 
 	var liveStatus, goneStatus string
@@ -191,5 +196,59 @@ func TestTeardownFailedRemoveLeavesDeletedAtNull(t *testing.T) {
 	}
 	if !deleted.Valid {
 		t.Fatal("deleted_at should be set after a successful remove")
+	}
+}
+
+func TestAbortStartIfInactiveKeepsCloneOnLookupError(t *testing.T) {
+	database := testDB(t)
+	root := filepath.Join(t.TempDir(), ".repos")
+	dir := mkdirPreview(t, root, "live")
+	insertDeployment(t, database, "live", "starting", "datetime('now')")
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !abortStartIfInactive(database, "live", dir) {
+		t.Fatal("lookup error should abort starting more work")
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("lookup error must not delete the clone: %v", err)
+	}
+
+	_, err := setStatusIfActive(database, "live", "running")
+	if err == nil {
+		t.Fatal("closed db should return an error, not a cancelled false")
+	}
+}
+
+func TestWaitInflightBlocksUntilEnd(t *testing.T) {
+	const uuid = "inflight-wait"
+	beginInflight(uuid)
+	done := make(chan bool, 1)
+	go func() {
+		done <- waitInflight(uuid, time.Second)
+	}()
+	select {
+	case <-done:
+		t.Fatal("waitInflight returned while work is in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+	endInflight(uuid)
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Fatal("waitInflight timed out while work should have ended")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waitInflight did not return after endInflight")
+	}
+}
+
+func TestWaitInflightTimesOut(t *testing.T) {
+	const uuid = "inflight-timeout"
+	beginInflight(uuid)
+	t.Cleanup(func() { endInflight(uuid) })
+	if waitInflight(uuid, 40*time.Millisecond) {
+		t.Fatal("waitInflight should time out while work is in flight")
 	}
 }

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -114,3 +114,82 @@ func TestExpireDeploymentsRemovesOldAndFailed(t *testing.T) {
 		t.Fatalf("fresh row mutated: status=%s deleted=%v", freshStatus, freshDeleted.Valid)
 	}
 }
+
+func TestSetStatusIfActiveIgnoresStopped(t *testing.T) {
+	database := testDB(t)
+	insertDeployment(t, database, "live", "starting", "datetime('now')")
+	insertDeployment(t, database, "gone", "starting", "datetime('now')")
+	markDeploymentStopped(database, "gone")
+
+	if !isDeploymentActive(database, "live") {
+		t.Fatal("starting row should be active")
+	}
+	if isDeploymentActive(database, "gone") {
+		t.Fatal("stopped row should not be active")
+	}
+	if !setStatusIfActive(database, "live", "running") {
+		t.Fatal("starting row should accept running")
+	}
+	if setStatusIfActive(database, "gone", "running") {
+		t.Fatal("stopped row must not accept running")
+	}
+	if setFailedIfActive(database, "gone", "clone failed") {
+		t.Fatal("stopped row must not accept failed")
+	}
+
+	var liveStatus, goneStatus string
+	if err := database.QueryRow(`SELECT status FROM deployments WHERE uuid = ?`, "live").Scan(&liveStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.QueryRow(`SELECT status FROM deployments WHERE uuid = ?`, "gone").Scan(&goneStatus); err != nil {
+		t.Fatal(err)
+	}
+	if liveStatus != "running" {
+		t.Fatalf("live status=%s", liveStatus)
+	}
+	if goneStatus != "stopped" {
+		t.Fatalf("gone status=%s", goneStatus)
+	}
+}
+
+func TestTeardownFailedRemoveLeavesDeletedAtNull(t *testing.T) {
+	database := testDB(t)
+	root := filepath.Join(t.TempDir(), ".repos")
+	dir := mkdirPreview(t, root, "busy")
+	insertDeployment(t, database, "busy", "running", "datetime('now')")
+
+	orig := removeAll
+	removeAll = func(string) error {
+		return os.ErrPermission
+	}
+	t.Cleanup(func() { removeAll = orig })
+
+	teardownDeployment(database, root, "busy")
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("clone should remain after failed remove: %v", err)
+	}
+	var status string
+	var deleted sql.NullString
+	if err := database.QueryRow(`SELECT status, deleted_at FROM deployments WHERE uuid = ?`, "busy").Scan(&status, &deleted); err != nil {
+		t.Fatal(err)
+	}
+	if status != "stopped" {
+		t.Fatalf("status=%s", status)
+	}
+	if deleted.Valid {
+		t.Fatal("deleted_at must stay null so the sweep retries")
+	}
+
+	removeAll = orig
+	expireDeployments(database, root, 7*24*time.Hour)
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("retry should remove clone, err=%v", err)
+	}
+	if err := database.QueryRow(`SELECT deleted_at FROM deployments WHERE uuid = ?`, "busy").Scan(&deleted); err != nil {
+		t.Fatal(err)
+	}
+	if !deleted.Valid {
+		t.Fatal("deleted_at should be set after a successful remove")
+	}
+}

--- a/db.go
+++ b/db.go
@@ -96,30 +96,33 @@ func restoreDeployments() {
 			if isEmptyOrOnlyGitFiles(deploymentDir) {
 				log.Infof("Repository not cloned or incomplete for UUID %s. Cloning now...", dep.UUID)
 				_, repoURL := extractPRID(dep.GitHubURL)
-				if abortStartIfInactive(dep.UUID, deploymentDir) {
+				if abortStartIfInactive(db, dep.UUID, deploymentDir) {
 					return
 				}
-				if out, err := cloneRepo(repoURL, dep.Branch, deploymentDir); err != nil {
+				beginInflight(dep.UUID)
+				out, err := cloneRepo(repoURL, dep.Branch, deploymentDir)
+				endInflight(dep.UUID)
+				if err != nil {
 					log.Infof("Failed to clone repository for UUID %s: %v", dep.UUID, out)
-					setFailedIfActive(db, dep.UUID, err.Error())
+					_, _ = setFailedIfActive(db, dep.UUID, err.Error())
 					return
 				}
 			}
 
-			if abortStartIfInactive(dep.UUID, deploymentDir) {
+			if abortStartIfInactive(db, dep.UUID, deploymentDir) {
 				return
 			}
 
 			mintFilePath := filepath.Join(deploymentDir, dep.DocsPath)
 			if _, err := os.Stat(mintFilePath); os.IsNotExist(err) {
-				setFailedIfActive(db, dep.UUID, "mint.json file not found")
+				_, _ = setFailedIfActive(db, dep.UUID, "mint.json file not found")
 				return
 			}
 
 			serverDir := filepath.Dir(mintFilePath)
 			port := extractPortFromURL(dep.DeployURL)
 
-			if abortStartIfInactive(dep.UUID, deploymentDir) {
+			if abortStartIfInactive(db, dep.UUID, deploymentDir) {
 				return
 			}
 
@@ -145,48 +148,55 @@ func isEmptyOrOnlyGitFiles(dir string) bool {
 	return true // Directory is empty or contains only Git files
 }
 
-func isDeploymentActive(database *sql.DB, uuid string) bool {
+func deploymentActive(database *sql.DB, uuid string) (bool, error) {
 	if database == nil {
-		return false
+		return false, errors.New("database is nil")
 	}
 	var n int
 	err := database.QueryRow(`
 		SELECT COUNT(*) FROM deployments
 		WHERE uuid = ? AND deleted_at IS NULL AND status IN ('starting', 'running')
 	`, uuid).Scan(&n)
-	return err == nil && n == 1
+	if err != nil {
+		return false, err
+	}
+	return n == 1, nil
 }
 
-func setStatusIfActive(database *sql.DB, uuid, status string) bool {
+func setStatusIfActive(database *sql.DB, uuid, status string) (bool, error) {
 	if database == nil {
-		return false
+		return false, errors.New("database is nil")
 	}
 	res, err := database.Exec(`
 		UPDATE deployments SET status = ?
 		WHERE uuid = ? AND deleted_at IS NULL AND status IN ('starting', 'running')
 	`, status, uuid)
 	if err != nil {
-		log.Errorf("Failed to update status for %s: %v", uuid, err)
-		return false
+		return false, err
 	}
-	n, _ := res.RowsAffected()
-	return n == 1
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n == 1, nil
 }
 
-func setFailedIfActive(database *sql.DB, uuid, errMsg string) bool {
+func setFailedIfActive(database *sql.DB, uuid, errMsg string) (bool, error) {
 	if database == nil {
-		return false
+		return false, errors.New("database is nil")
 	}
 	res, err := database.Exec(`
 		UPDATE deployments SET status = ?, error = ?
 		WHERE uuid = ? AND deleted_at IS NULL AND status IN ('starting', 'running')
 	`, "failed", errMsg, uuid)
 	if err != nil {
-		log.Errorf("Failed to update status for %s: %v", uuid, err)
-		return false
+		return false, err
 	}
-	n, _ := res.RowsAffected()
-	return n == 1
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n == 1, nil
 }
 
 func markDeploymentStopped(database *sql.DB, uuid string) {

--- a/db.go
+++ b/db.go
@@ -96,15 +96,14 @@ func restoreDeployments() {
 			if isEmptyOrOnlyGitFiles(deploymentDir) {
 				log.Infof("Repository not cloned or incomplete for UUID %s. Cloning now...", dep.UUID)
 				_, repoURL := extractPRID(dep.GitHubURL)
-				if abortStartIfInactive(db, dep.UUID, deploymentDir) {
+				aborted, err := cloneIfActive(db, dep.UUID, repoURL, dep.Branch, deploymentDir)
+				if aborted {
 					return
 				}
-				beginInflight(dep.UUID)
-				out, err := cloneRepo(repoURL, dep.Branch, deploymentDir)
-				endInflight(dep.UUID)
 				if err != nil {
-					log.Infof("Failed to clone repository for UUID %s: %v", dep.UUID, out)
+					log.Infof("Failed to clone repository for UUID %s: %v", dep.UUID, err)
 					_, _ = setFailedIfActive(db, dep.UUID, err.Error())
+					_ = abortStartIfInactive(db, dep.UUID, deploymentDir)
 					return
 				}
 			}

--- a/db.go
+++ b/db.go
@@ -96,27 +96,32 @@ func restoreDeployments() {
 			if isEmptyOrOnlyGitFiles(deploymentDir) {
 				log.Infof("Repository not cloned or incomplete for UUID %s. Cloning now...", dep.UUID)
 				_, repoURL := extractPRID(dep.GitHubURL)
+				if abortStartIfInactive(dep.UUID, deploymentDir) {
+					return
+				}
 				if out, err := cloneRepo(repoURL, dep.Branch, deploymentDir); err != nil {
 					log.Infof("Failed to clone repository for UUID %s: %v", dep.UUID, out)
-					_, err2 := db.Exec("UPDATE deployments SET status = ?, error = ? WHERE uuid = ?", "failed", err.Error(), dep.UUID)
-					if err2 != nil {
-						log.Infof("Failed to update status for UUID %s: %v for error %+v", dep.UUID, err2, err)
-					}
+					setFailedIfActive(db, dep.UUID, err.Error())
 					return
 				}
 			}
 
+			if abortStartIfInactive(dep.UUID, deploymentDir) {
+				return
+			}
+
 			mintFilePath := filepath.Join(deploymentDir, dep.DocsPath)
 			if _, err := os.Stat(mintFilePath); os.IsNotExist(err) {
-				_, err2 := db.Exec("UPDATE deployments SET status = ?, error = ? WHERE uuid = ?", "failed", "mint.json file not found", dep.UUID)
-				if err2 != nil {
-					log.Infof("Failed to update status for UUID %s: %v for error %+v", dep.UUID, err2, err)
-				}
+				setFailedIfActive(db, dep.UUID, "mint.json file not found")
 				return
 			}
 
 			serverDir := filepath.Dir(mintFilePath)
 			port := extractPortFromURL(dep.DeployURL)
+
+			if abortStartIfInactive(dep.UUID, deploymentDir) {
+				return
+			}
 
 			startMintlifyDev(dep.UUID, port, serverDir)
 		}()
@@ -138,6 +143,76 @@ func isEmptyOrOnlyGitFiles(dir string) bool {
 	}
 
 	return true // Directory is empty or contains only Git files
+}
+
+func isDeploymentActive(database *sql.DB, uuid string) bool {
+	if database == nil {
+		return false
+	}
+	var n int
+	err := database.QueryRow(`
+		SELECT COUNT(*) FROM deployments
+		WHERE uuid = ? AND deleted_at IS NULL AND status IN ('starting', 'running')
+	`, uuid).Scan(&n)
+	return err == nil && n == 1
+}
+
+func setStatusIfActive(database *sql.DB, uuid, status string) bool {
+	if database == nil {
+		return false
+	}
+	res, err := database.Exec(`
+		UPDATE deployments SET status = ?
+		WHERE uuid = ? AND deleted_at IS NULL AND status IN ('starting', 'running')
+	`, status, uuid)
+	if err != nil {
+		log.Errorf("Failed to update status for %s: %v", uuid, err)
+		return false
+	}
+	n, _ := res.RowsAffected()
+	return n == 1
+}
+
+func setFailedIfActive(database *sql.DB, uuid, errMsg string) bool {
+	if database == nil {
+		return false
+	}
+	res, err := database.Exec(`
+		UPDATE deployments SET status = ?, error = ?
+		WHERE uuid = ? AND deleted_at IS NULL AND status IN ('starting', 'running')
+	`, "failed", errMsg, uuid)
+	if err != nil {
+		log.Errorf("Failed to update status for %s: %v", uuid, err)
+		return false
+	}
+	n, _ := res.RowsAffected()
+	return n == 1
+}
+
+func markDeploymentStopped(database *sql.DB, uuid string) {
+	if database == nil {
+		return
+	}
+	_, err := database.Exec(`
+		UPDATE deployments SET status = ?
+		WHERE uuid = ? AND deleted_at IS NULL
+	`, "stopped", uuid)
+	if err != nil {
+		log.Errorf("Failed to mark deployment %s stopped: %v", uuid, err)
+	}
+}
+
+func markDeploymentDeleted(database *sql.DB, uuid string) {
+	if database == nil {
+		return
+	}
+	_, err := database.Exec(`
+		UPDATE deployments SET deleted_at = CURRENT_TIMESTAMP
+		WHERE uuid = ? AND deleted_at IS NULL
+	`, uuid)
+	if err != nil {
+		log.Errorf("Failed to mark deployment %s deleted: %v", uuid, err)
+	}
 }
 
 func extractPortFromURL(deployURL string) int {

--- a/db.go
+++ b/db.go
@@ -64,14 +64,13 @@ func initDB() {
 }
 
 func restoreDeployments() {
-	// TODO: Stop deployments after x number of days
 	dir, err := os.Getwd()
 	if err != nil {
 		log.Fatal("Failed to get working directory")
 		return
 	}
 
-	rows, err := db.Query("SELECT uuid, github_url, branch, docs_path, deployment_url, status FROM deployments WHERE status IN ('running', 'starting')")
+	rows, err := db.Query("SELECT uuid, github_url, branch, docs_path, deployment_url, status FROM deployments WHERE status IN ('running', 'starting') AND deleted_at IS NULL")
 	if err != nil {
 		log.Fatalf("Failed to query deployments: %v", err)
 	}

--- a/handler.go
+++ b/handler.go
@@ -55,6 +55,7 @@ func createDeploymentHandler(w http.ResponseWriter, r *http.Request) {
 
 	_, repoURL := extractPRID(req.GitHubURL)
 	if err := checkRepoExists(repoURL, req.Branch); err != nil {
+		_ = os.RemoveAll(deploymentDir)
 		http.Error(w, fmt.Sprintf("Repository check failed: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -169,15 +170,18 @@ func extractPRID(githubURL string) (string, string) {
 func deleteDeploymentHandler(w http.ResponseWriter, r *http.Request) {
 	uuid := chi.URLParam(r, "uuid")
 
-	err := stopMintlifyServer(uuid)
+	var existing string
+	err := db.QueryRow("SELECT uuid FROM deployments WHERE uuid = ?", uuid).Scan(&existing)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, "Deployment not found", http.StatusNotFound)
+			return
 		}
+		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
 	}
+
+	teardownDeployment(db, reposRoot(), uuid)
 
 	w.WriteHeader(http.StatusOK)
 	_, err = fmt.Fprintf(w, "Mintlify server for UUID %s stopped", uuid)

--- a/handler.go
+++ b/handler.go
@@ -82,8 +82,15 @@ func createDeploymentHandler(w http.ResponseWriter, r *http.Request) {
 	startProcessing(newUUID, repoURL, req, deploymentDir, port)
 }
 
-func abortStartIfInactive(uuid, dir string) bool {
-	if isDeploymentActive(db, uuid) {
+func abortStartIfInactive(database *sql.DB, uuid, dir string) bool {
+	// A lookup error is unknown, not cancelled: stop starting more work
+	// but do not delete the clone.
+	active, err := deploymentActive(database, uuid)
+	if err != nil {
+		log.Errorf("Failed to check deployment %s: %v", uuid, err)
+		return true
+	}
+	if active {
 		return false
 	}
 	_ = os.RemoveAll(dir)
@@ -92,36 +99,39 @@ func abortStartIfInactive(uuid, dir string) bool {
 
 func startProcessing(newUUID string, repoURL string, req Deployment, deploymentDir string, port int) {
 	go func() {
-		if abortStartIfInactive(newUUID, deploymentDir) {
+		if abortStartIfInactive(db, newUUID, deploymentDir) {
 			return
 		}
 		if err := ensureMintlifyInstalled(); err != nil {
 			log.Infof("Failed to install Mintlify: %v", err)
-			setFailedIfActive(db, newUUID, err.Error())
+			_, _ = setFailedIfActive(db, newUUID, err.Error())
 			return
 		}
 
-		if abortStartIfInactive(newUUID, deploymentDir) {
+		if abortStartIfInactive(db, newUUID, deploymentDir) {
 			return
 		}
-		if _, err := cloneRepo(repoURL, req.Branch, deploymentDir); err != nil {
+		beginInflight(newUUID)
+		_, err := cloneRepo(repoURL, req.Branch, deploymentDir)
+		endInflight(newUUID)
+		if err != nil {
 			log.Errorln(err)
-			setFailedIfActive(db, newUUID, err.Error())
+			_, _ = setFailedIfActive(db, newUUID, err.Error())
 			return
 		}
 
-		if abortStartIfInactive(newUUID, deploymentDir) {
+		if abortStartIfInactive(db, newUUID, deploymentDir) {
 			return
 		}
 		mintFilePath := filepath.Join(deploymentDir, req.DocsPath)
 		if _, err := os.Stat(mintFilePath); os.IsNotExist(err) {
-			setFailedIfActive(db, newUUID, "mint.json file not found")
+			_, _ = setFailedIfActive(db, newUUID, "mint.json file not found")
 			return
 		}
 
 		serverDir := filepath.Dir(mintFilePath)
 
-		if abortStartIfInactive(newUUID, deploymentDir) {
+		if abortStartIfInactive(db, newUUID, deploymentDir) {
 			return
 		}
 		startMintlifyDev(newUUID, port, serverDir)

--- a/handler.go
+++ b/handler.go
@@ -82,28 +82,48 @@ func createDeploymentHandler(w http.ResponseWriter, r *http.Request) {
 	startProcessing(newUUID, repoURL, req, deploymentDir, port)
 }
 
+func abortStartIfInactive(uuid, dir string) bool {
+	if isDeploymentActive(db, uuid) {
+		return false
+	}
+	_ = os.RemoveAll(dir)
+	return true
+}
+
 func startProcessing(newUUID string, repoURL string, req Deployment, deploymentDir string, port int) {
 	go func() {
+		if abortStartIfInactive(newUUID, deploymentDir) {
+			return
+		}
 		if err := ensureMintlifyInstalled(); err != nil {
 			log.Infof("Failed to install Mintlify: %v", err)
-			_, _ = db.Exec("UPDATE deployments SET status = ?, error = ? WHERE uuid = ?", "failed", err.Error(), newUUID)
+			setFailedIfActive(db, newUUID, err.Error())
 			return
 		}
 
+		if abortStartIfInactive(newUUID, deploymentDir) {
+			return
+		}
 		if _, err := cloneRepo(repoURL, req.Branch, deploymentDir); err != nil {
 			log.Errorln(err)
-			_, _ = db.Exec("UPDATE deployments SET status = ?, error = ? WHERE uuid = ?", "failed", err.Error(), newUUID)
+			setFailedIfActive(db, newUUID, err.Error())
 			return
 		}
 
+		if abortStartIfInactive(newUUID, deploymentDir) {
+			return
+		}
 		mintFilePath := filepath.Join(deploymentDir, req.DocsPath)
 		if _, err := os.Stat(mintFilePath); os.IsNotExist(err) {
-			_, _ = db.Exec("UPDATE deployments SET status = ?, error = ? WHERE uuid = ?", "failed", "mint.json file not found", newUUID)
+			setFailedIfActive(db, newUUID, "mint.json file not found")
 			return
 		}
 
 		serverDir := filepath.Dir(mintFilePath)
 
+		if abortStartIfInactive(newUUID, deploymentDir) {
+			return
+		}
 		startMintlifyDev(newUUID, port, serverDir)
 	}()
 }

--- a/handler.go
+++ b/handler.go
@@ -82,6 +82,16 @@ func createDeploymentHandler(w http.ResponseWriter, r *http.Request) {
 	startProcessing(newUUID, repoURL, req, deploymentDir, port)
 }
 
+func cloneIfActive(database *sql.DB, uuid, repoURL, branch, dir string) (bool, error) {
+	beginInflight(uuid)
+	defer endInflight(uuid)
+	if abortStartIfInactive(database, uuid, dir) {
+		return true, nil
+	}
+	_, err := cloneRepo(repoURL, branch, dir)
+	return false, err
+}
+
 func abortStartIfInactive(database *sql.DB, uuid, dir string) bool {
 	// A lookup error is unknown, not cancelled: stop starting more work
 	// but do not delete the clone.
@@ -108,15 +118,14 @@ func startProcessing(newUUID string, repoURL string, req Deployment, deploymentD
 			return
 		}
 
-		if abortStartIfInactive(db, newUUID, deploymentDir) {
+		aborted, err := cloneIfActive(db, newUUID, repoURL, req.Branch, deploymentDir)
+		if aborted {
 			return
 		}
-		beginInflight(newUUID)
-		_, err := cloneRepo(repoURL, req.Branch, deploymentDir)
-		endInflight(newUUID)
 		if err != nil {
 			log.Errorln(err)
 			_, _ = setFailedIfActive(db, newUUID, err.Error())
+			_ = abortStartIfInactive(db, newUUID, deploymentDir)
 			return
 		}
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 func main() {
 	initDB()
+	startCleanupLoop()
 	restoreDeployments()
 
 	r := chi.NewRouter()

--- a/mintlify.go
+++ b/mintlify.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"mintlify-previewer-backend/log"
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -112,10 +114,7 @@ func killProcessGroup(server *trackedServer) error {
 		return nil
 	}
 	if server.pgid > 0 {
-		if err := syscall.Kill(-server.pgid, syscall.SIGTERM); err != nil {
-			return server.proc.Signal(syscall.SIGTERM)
-		}
-		return nil
+		return syscall.Kill(-server.pgid, syscall.SIGTERM)
 	}
 	return server.proc.Signal(syscall.SIGTERM)
 }
@@ -127,7 +126,7 @@ func waitProcessGone(server *trackedServer, d time.Duration) {
 	pid := server.proc.Pid
 	deadline := time.Now().Add(d)
 	for {
-		reapZombieChildren()
+		reapGroupZombies(server.pgid, pid)
 		if processGroupGone(server.pgid, pid) {
 			return
 		}
@@ -143,13 +142,13 @@ func waitProcessGone(server *trackedServer, d time.Duration) {
 	}
 	deadline = time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
-		reapZombieChildren()
+		reapGroupZombies(server.pgid, pid)
 		if processGroupGone(server.pgid, pid) {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	reapZombieChildren()
+	reapGroupZombies(server.pgid, pid)
 }
 
 func processGroupGone(pgid, leaderPid int) bool {
@@ -169,12 +168,51 @@ func processReaped(pid int) bool {
 	return wpid == pid
 }
 
-func reapZombieChildren() {
-	for {
+func reapGroupZombies(pgid, leaderPid int) {
+	_ = processReaped(leaderPid)
+	for _, pid := range groupMemberPids(pgid) {
 		var status syscall.WaitStatus
-		wpid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
-		if err != nil || wpid <= 0 {
-			return
+		_, _ = syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
+	}
+}
+
+func groupMemberPids(pgid int) []int {
+	if pgid <= 0 {
+		return nil
+	}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	var pids []int
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		if procPgid(pid) == pgid {
+			pids = append(pids, pid)
 		}
 	}
+	return pids
+}
+
+func procPgid(pid int) int {
+	b, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return -1
+	}
+	i := bytes.LastIndexByte(b, ')')
+	if i < 0 || i+2 >= len(b) {
+		return -1
+	}
+	fields := strings.Fields(string(b[i+2:]))
+	if len(fields) < 3 {
+		return -1
+	}
+	pgrp, err := strconv.Atoi(fields[2])
+	if err != nil {
+		return -1
+	}
+	return pgrp
 }

--- a/mintlify.go
+++ b/mintlify.go
@@ -30,7 +30,15 @@ func ensureMintlifyInstalled() error {
 }
 
 func startMintlifyDev(uuid string, port int, dir string) {
-	if !isDeploymentActive(db, uuid) {
+	beginInflight(uuid)
+	active, err := deploymentActive(db, uuid)
+	if err != nil {
+		endInflight(uuid)
+		log.Errorf("Failed to check deployment %s: %v", uuid, err)
+		return
+	}
+	if !active {
+		endInflight(uuid)
 		return
 	}
 
@@ -39,8 +47,9 @@ func startMintlifyDev(uuid string, port int, dir string) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {
+		endInflight(uuid)
 		log.Errorf("Failed to start Mintlify: %v", err)
-		setFailedIfActive(db, uuid, err.Error())
+		_, _ = setFailedIfActive(db, uuid, err.Error())
 		return
 	}
 
@@ -49,15 +58,20 @@ func startMintlifyDev(uuid string, port int, dir string) {
 	mu.Lock()
 	activeServers[uuid] = &trackedServer{proc: cmd.Process, pgid: cmd.Process.Pid}
 	mu.Unlock()
+	endInflight(uuid)
 
 	log.Infof("Mintlify running for UUID %s on port %d", uuid, port)
-	if !setStatusIfActive(db, uuid, "running") {
+	ok, err := setStatusIfActive(db, uuid, "running")
+	if err != nil {
+		// Unknown is not cancelled: keep the process we just started.
+		log.Errorf("Failed to mark running for %s: %v", uuid, err)
+	} else if !ok {
 		stopMintlifyProcess(uuid)
+		_ = cmd.Wait()
 		return
 	}
 
-	err := cmd.Wait()
-	if err != nil {
+	if err := cmd.Wait(); err != nil {
 		log.Errorf("Failed to start Mintlify: %v", err)
 	}
 
@@ -109,7 +123,8 @@ func waitProcessGone(server *trackedServer, d time.Duration) {
 	pid := server.proc.Pid
 	deadline := time.Now().Add(d)
 	for {
-		if processReaped(pid) {
+		_ = processReaped(pid)
+		if processGroupGone(server.pgid, pid) {
 			return
 		}
 		if !time.Now().Before(deadline) {
@@ -117,18 +132,28 @@ func waitProcessGone(server *trackedServer, d time.Duration) {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	if server.pgid > 0 {
+	if server.pgid > 0 && !processGroupGone(server.pgid, pid) {
 		_ = syscall.Kill(-server.pgid, syscall.SIGKILL)
-	} else {
+	} else if server.pgid <= 0 {
 		_ = server.proc.Signal(syscall.SIGKILL)
 	}
 	deadline = time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
-		if processReaped(pid) {
+		_ = processReaped(pid)
+		if processGroupGone(server.pgid, pid) {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
+	_ = processReaped(pid)
+}
+
+func processGroupGone(pgid, leaderPid int) bool {
+	if pgid <= 0 {
+		return processReaped(leaderPid)
+	}
+	err := syscall.Kill(-pgid, 0)
+	return err == syscall.ESRCH
 }
 
 func processReaped(pid int) bool {

--- a/mintlify.go
+++ b/mintlify.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"sync"
 	"syscall"
+	"time"
 )
 
 type trackedServer struct {
@@ -29,13 +30,17 @@ func ensureMintlifyInstalled() error {
 }
 
 func startMintlifyDev(uuid string, port int, dir string) {
+	if !isDeploymentActive(db, uuid) {
+		return
+	}
+
 	cmd := exec.Command("mintlify", "dev", "--no-open", "--port", strconv.Itoa(port))
 	cmd.Dir = dir
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {
 		log.Errorf("Failed to start Mintlify: %v", err)
-		_, _ = db.Exec("UPDATE deployments SET status = ? WHERE uuid = ?", "failed", uuid)
+		setFailedIfActive(db, uuid, err.Error())
 		return
 	}
 
@@ -46,12 +51,12 @@ func startMintlifyDev(uuid string, port int, dir string) {
 	mu.Unlock()
 
 	log.Infof("Mintlify running for UUID %s on port %d", uuid, port)
-	_, err := db.Exec("UPDATE deployments SET status = ? WHERE uuid = ?", "running", uuid)
-	if err != nil {
-		log.Errorf("Failed to update running status: %v", err)
+	if !setStatusIfActive(db, uuid, "running") {
+		stopMintlifyProcess(uuid)
+		return
 	}
 
-	err = cmd.Wait()
+	err := cmd.Wait()
 	if err != nil {
 		log.Errorf("Failed to start Mintlify: %v", err)
 	}
@@ -76,6 +81,7 @@ func stopMintlifyProcess(uuid string) {
 	if err := killProcessGroup(server); err != nil {
 		log.Errorf("Failed to stop Mintlify server for %s: %v", uuid, err)
 	}
+	waitProcessGone(server, 5*time.Second)
 }
 
 func killProcessGroup(server *trackedServer) error {
@@ -94,4 +100,42 @@ func killProcessGroup(server *trackedServer) error {
 		return nil
 	}
 	return server.proc.Signal(syscall.SIGTERM)
+}
+
+func waitProcessGone(server *trackedServer, d time.Duration) {
+	if server == nil || server.proc == nil {
+		return
+	}
+	pid := server.proc.Pid
+	deadline := time.Now().Add(d)
+	for {
+		if processReaped(pid) {
+			return
+		}
+		if !time.Now().Before(deadline) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if server.pgid > 0 {
+		_ = syscall.Kill(-server.pgid, syscall.SIGKILL)
+	} else {
+		_ = server.proc.Signal(syscall.SIGKILL)
+	}
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if processReaped(pid) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func processReaped(pid int) bool {
+	var status syscall.WaitStatus
+	wpid, err := syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
+	if err == syscall.ECHILD {
+		return true
+	}
+	return wpid == pid
 }

--- a/mintlify.go
+++ b/mintlify.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"mintlify-previewer-backend/log"
 	"os"
 	"os/exec"
@@ -27,6 +26,7 @@ func ensureMintlifyInstalled() error {
 func startMintlifyDev(uuid string, port int, dir string) {
 	cmd := exec.Command("mintlify", "dev", "--no-open", "--port", strconv.Itoa(port))
 	cmd.Dir = dir
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {
 		log.Errorf("Failed to start Mintlify: %v", err)
@@ -54,27 +54,27 @@ func startMintlifyDev(uuid string, port int, dir string) {
 	mu.Unlock()
 }
 
-func stopMintlifyServer(uuid string) error {
+func stopMintlifyProcess(uuid string) {
 	mu.Lock()
 	process, exists := activeServers[uuid]
+	if exists {
+		delete(activeServers, uuid)
+	}
 	mu.Unlock()
 
 	if !exists {
-		log.Errorf("server for UUID %s not found", uuid)
-		return fmt.Errorf("server for UUID %s not found", uuid)
+		return
 	}
 
-	if err := process.Signal(syscall.SIGTERM); err != nil {
-		log.Errorf("Failed to stop Mintlify server: %v", err)
-		return fmt.Errorf("failed to stop server for UUID %s: %v", uuid, err)
+	if err := killProcessGroup(process); err != nil {
+		log.Errorf("Failed to stop Mintlify server for %s: %v", uuid, err)
 	}
+}
 
-	mu.Lock()
-	delete(activeServers, uuid)
-	mu.Unlock()
-
-	log.Infof("Mintlify server for UUID %s stopped", uuid)
-	_, err := db.Exec("UPDATE deployments SET status = ? WHERE uuid = ?", "stopped", uuid)
-
-	return err
+func killProcessGroup(process *os.Process) error {
+	pgid, err := syscall.Getpgid(process.Pid)
+	if err == nil {
+		return syscall.Kill(-pgid, syscall.SIGTERM)
+	}
+	return process.Signal(syscall.SIGTERM)
 }

--- a/mintlify.go
+++ b/mintlify.go
@@ -62,6 +62,10 @@ func startMintlifyDev(uuid string, port int, dir string) {
 
 	log.Infof("Mintlify running for UUID %s on port %d", uuid, port)
 	ok, err := setStatusIfActive(db, uuid, "running")
+	for i := 0; err != nil && i < 3; i++ {
+		time.Sleep(50 * time.Millisecond)
+		ok, err = setStatusIfActive(db, uuid, "running")
+	}
 	if err != nil {
 		// Unknown is not cancelled: keep the process we just started.
 		log.Errorf("Failed to mark running for %s: %v", uuid, err)
@@ -123,7 +127,7 @@ func waitProcessGone(server *trackedServer, d time.Duration) {
 	pid := server.proc.Pid
 	deadline := time.Now().Add(d)
 	for {
-		_ = processReaped(pid)
+		reapZombieChildren()
 		if processGroupGone(server.pgid, pid) {
 			return
 		}
@@ -139,13 +143,13 @@ func waitProcessGone(server *trackedServer, d time.Duration) {
 	}
 	deadline = time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
-		_ = processReaped(pid)
+		reapZombieChildren()
 		if processGroupGone(server.pgid, pid) {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	_ = processReaped(pid)
+	reapZombieChildren()
 }
 
 func processGroupGone(pgid, leaderPid int) bool {
@@ -163,4 +167,14 @@ func processReaped(pid int) bool {
 		return true
 	}
 	return wpid == pid
+}
+
+func reapZombieChildren() {
+	for {
+		var status syscall.WaitStatus
+		wpid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
+		if err != nil || wpid <= 0 {
+			return
+		}
+	}
 }

--- a/mintlify.go
+++ b/mintlify.go
@@ -9,7 +9,12 @@ import (
 	"syscall"
 )
 
-var activeServers = make(map[string]*os.Process)
+type trackedServer struct {
+	proc *os.Process
+	pgid int
+}
+
+var activeServers = make(map[string]*trackedServer)
 var mu sync.Mutex
 
 func ensureMintlifyInstalled() error {
@@ -34,8 +39,10 @@ func startMintlifyDev(uuid string, port int, dir string) {
 		return
 	}
 
+	// Setpgid makes the child's pid the new process group. Record it now so
+	// teardown never Getpgid's a pid that may have been reused.
 	mu.Lock()
-	activeServers[uuid] = cmd.Process
+	activeServers[uuid] = &trackedServer{proc: cmd.Process, pgid: cmd.Process.Pid}
 	mu.Unlock()
 
 	log.Infof("Mintlify running for UUID %s on port %d", uuid, port)
@@ -56,7 +63,7 @@ func startMintlifyDev(uuid string, port int, dir string) {
 
 func stopMintlifyProcess(uuid string) {
 	mu.Lock()
-	process, exists := activeServers[uuid]
+	server, exists := activeServers[uuid]
 	if exists {
 		delete(activeServers, uuid)
 	}
@@ -66,15 +73,25 @@ func stopMintlifyProcess(uuid string) {
 		return
 	}
 
-	if err := killProcessGroup(process); err != nil {
+	if err := killProcessGroup(server); err != nil {
 		log.Errorf("Failed to stop Mintlify server for %s: %v", uuid, err)
 	}
 }
 
-func killProcessGroup(process *os.Process) error {
-	pgid, err := syscall.Getpgid(process.Pid)
-	if err == nil {
-		return syscall.Kill(-pgid, syscall.SIGTERM)
+func killProcessGroup(server *trackedServer) error {
+	if server == nil || server.proc == nil {
+		return nil
 	}
-	return process.Signal(syscall.SIGTERM)
+	// Fail closed on strangers: if this pid is already gone, do not signal a
+	// process group that may now belong to an unrelated process.
+	if err := server.proc.Signal(syscall.Signal(0)); err != nil {
+		return nil
+	}
+	if server.pgid > 0 {
+		if err := syscall.Kill(-server.pgid, syscall.SIGTERM); err != nil {
+			return server.proc.Signal(syscall.SIGTERM)
+		}
+		return nil
+	}
+	return server.proc.Signal(syscall.SIGTERM)
 }

--- a/mintlify_test.go
+++ b/mintlify_test.go
@@ -4,6 +4,7 @@ import (
 	"os/exec"
 	"syscall"
 	"testing"
+	"time"
 )
 
 func TestKillProcessGroupSkipsExitedPid(t *testing.T) {
@@ -25,5 +26,27 @@ func TestKillProcessGroupSkipsExitedPid(t *testing.T) {
 func TestKillProcessGroupNilServer(t *testing.T) {
 	if err := killProcessGroup(nil); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestWaitProcessGoneAfterTerm(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := cmd.Process.Signal(syscall.Signal(0)); err == nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		_ = cmd.Wait()
+	})
+	server := &trackedServer{proc: cmd.Process, pgid: cmd.Process.Pid}
+	if err := killProcessGroup(server); err != nil {
+		t.Fatal(err)
+	}
+	waitProcessGone(server, 2*time.Second)
+	if err := cmd.Process.Signal(syscall.Signal(0)); err == nil {
+		t.Fatal("process should be gone after wait")
 	}
 }

--- a/mintlify_test.go
+++ b/mintlify_test.go
@@ -50,3 +50,33 @@ func TestWaitProcessGoneAfterTerm(t *testing.T) {
 		t.Fatal("process should be gone after wait")
 	}
 }
+
+func TestWaitProcessGoneWaitsForGroup(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "sleep 30 & exit 0")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pgid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if !processGroupGone(pgid, cmd.Process.Pid) {
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		}
+	})
+	deadline := time.Now().Add(time.Second)
+	for processGroupGone(pgid, cmd.Process.Pid) {
+		if !time.Now().Before(deadline) {
+			t.Fatal("expected leftover child in the process group")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	server := &trackedServer{proc: cmd.Process, pgid: pgid}
+	_ = syscall.Kill(-pgid, syscall.SIGTERM)
+	waitProcessGone(server, 2*time.Second)
+	if !processGroupGone(pgid, cmd.Process.Pid) {
+		t.Fatal("leftover group members should be gone")
+	}
+}

--- a/mintlify_test.go
+++ b/mintlify_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+func TestKillProcessGroupSkipsExitedPid(t *testing.T) {
+	cmd := exec.Command("true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := killProcessGroup(&trackedServer{proc: cmd.Process, pgid: cmd.Process.Pid})
+	if err != nil {
+		t.Fatalf("dead pid should be a no-op, got %v", err)
+	}
+}
+
+func TestKillProcessGroupNilServer(t *testing.T) {
+	if err := killProcessGroup(nil); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- Each `/deploy` cloned the full website tree into `.repos/<uuid>` and never deleted it, so the preview disk grew without bound.
- Failed and stopped previews are removed immediately. Running ones are stopped, deleted, and marked `deleted_at` after 7 days. Hourly sweep also drops stale orphan directories.
- Restore on boot skips expired rows. DELETE now removes the clone, not only the mintlify process.

## Test plan
- [x] `CGO_ENABLED=1 go test ./...`
- [ ] After merge, tag `v0.1.4` so the image build runs, then point the VM compose image at that tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process management, filesystem deletion, and deployment state on boot/restore and DELETE; race handling is tested but mistakes could stop wrong processes or delete active previews.
> 
> **Overview**
> Adds **automatic preview lifecycle cleanup** so `.repos/<uuid>` clones and Mintlify processes do not accumulate forever. An hourly sweep expires deployments older than **7 days**, removes **failed/stopped** rows immediately, and deletes **stale orphan** directories on disk. Teardown marks rows **stopped** first, waits for in-flight clone/start work, stops the process group, removes the clone, then sets **`deleted_at`** (retries if disk removal fails).
> 
> **Start/delete/restore** paths are aligned with that model: boot restore skips **`deleted_at`** rows; status updates go through **active-only** helpers so stopped previews cannot flip back to **running**; clone/start aborts when a deployment is no longer active. **DELETE** now runs full teardown (clone + process), not only stopping Mintlify.
> 
> Mintlify shutdown is reworked to track **process groups** (SIGTERM/SIGKILL, `/proc` reaping) so child processes are not left behind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63cbd9406190d970b1afaf59577447ad0b18dd93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->